### PR TITLE
fix: new fungible builder

### DIFF
--- a/fungible/package/src/lib.rs
+++ b/fungible/package/src/lib.rs
@@ -10,7 +10,8 @@ mod faucet_template {
 
     impl TestFaucet {
         pub fn mint(initial_supply: Amount, token_symbol: String) -> Self {
-            let coins = ResourceBuilder::fungible(&token_symbol)
+            let coins = ResourceBuilder::fungible()
+                .with_token_symbol(&token_symbol)
                 .initial_supply(initial_supply)
                 .build_bucket();
 

--- a/swap/package/src/lib.rs
+++ b/swap/package/src/lib.rs
@@ -57,7 +57,7 @@ mod tariswap {
 
             // create the lp resource
             // TODO: add lp resource minting/burning security, only this component should be allowed
-            let lp_resource = ResourceBuilder::fungible("LP").build();
+            let lp_resource = ResourceBuilder::fungible().with_token_symbol("LP").build();
 
             Self {
                 pools,


### PR DESCRIPTION
Update the fungible creation to the new format (using `with_token_symbol`)