### PR TITLE
Update path to templates in README

### DIFF
--- a/wasm_templates/README.md
+++ b/wasm_templates/README.md
@@ -8,5 +8,5 @@ cargo install cargo-generate
 
 Then create a new project (replace `fungible` with the template you want to use):
 ```
-cargo generate https://github.com/tari-project/wasm-template.git fungible
+cargo generate https://github.com/tari-project/wasm-template.git wasm_templates/fungible
 ```


### PR DESCRIPTION
Current path doesn't include wasm_templates which results in errors:

```bash
⚠️   Favorite `https://github.com/tari-project/wasm-template.git` not found in config, using it as a git repository: https://github.com/tari-project/wasm-template.git
Error: not able to find subfolder 'nft' in source template
```

This change simply adds missing path element to make it work.