### PR TITLE
fix: nft template build

### DIFF
--- a/wasm_templates/nft/Cargo.toml
+++ b/wasm_templates/nft/Cargo.toml
@@ -10,9 +10,6 @@ edition = "2024"
 tari_template_lib = { version = "0.20" }
 serde = { version = "1.0.143", default-features = false, features = ["derive", "alloc"] }
 
-[dev-dependencies]
-tari_template_test_tooling = "0.25"
-
 {% if in_cargo_workspace == "false" %}
 [profile.release]
 opt-level = 's'     # Optimize for size.
@@ -27,6 +24,6 @@ crate-type = ["cdylib"]
 
 [dev-dependencies]
 log = "*"
-tari_template_test_tooling = {git = "https://github.com/tari-project/tari-ootle.git", tag = "v0.23.0" }
-tari_engine_types = { git = "https://github.com/tari-project/tari-ootle.git", tag = "v0.23.0"}
-tari_transaction = { git = "https://github.com/tari-project/tari-ootle.git", tag = "v0.23.0" }
+tari_template_test_tooling = { git = "https://github.com/tari-project/tari-ootle.git", tag = "v0.27.0"}
+tari_engine_types = { git = "https://github.com/tari-project/tari-ootle.git", tag = "v0.27.0"}
+tari_ootle_transaction = { git = "https://github.com/tari-project/tari-ootle.git", tag = "v0.27.0"}

--- a/wasm_templates/nft/src/lib.rs
+++ b/wasm_templates/nft/src/lib.rs
@@ -62,7 +62,7 @@ mod {{ project-name | snake_case }} {
         }
 
         pub fn mint_specific(&mut self, id: NonFungibleId) -> Bucket {
-            debug!(format!("Minting {}", id));
+            debug!("Minting {}", id);
             // These are characteristic of the NFT and are immutable
             let mut immutable_data = Metadata::new();
             immutable_data
@@ -82,7 +82,7 @@ mod {{ project-name | snake_case }} {
         }
 
         pub fn inc_brightness(&mut self, id: NonFungibleId, brightness: u32) {
-            debug!(format!("Increase brightness on {} by {}", id, brightness));
+            debug!("Increase brightness on {} by {}", id, brightness);
             self.with_data_mut(id, |data| {
                 data.brightness = data
                     .brightness
@@ -109,11 +109,7 @@ mod {{ project-name | snake_case }} {
                 bucket.resource_address() == self.resource_address,
                 "Cannot burn bucket not from this collection"
             );
-            debug!(format!(
-                "Burning bucket {} containing {}",
-                bucket,
-                bucket.amount()
-            ));
+            debug!("Burning bucket {} containing {}", bucket, bucket.amount());
             // This is all that's required, typically the template would not need to include a burn function because a
             // native instruction can be used instead
             bucket.burn();


### PR DESCRIPTION
## Description

This pull request fixes the nft template, which had conflicting dependencies. It also fixes (or updates?) the calls the the debug macro in that template.

## Testing instructions

1. Clone this repository
2. `cargo install cargo-generate`
3. In a clean directory, run `cargo generate /path/to/cloned/repo wasm_templates/nft` where `/path/to/cloned` is the path to your cloned copy of this repository.
4. Fill in the prompt
5. `cd` into your newly created project directory and run `cargo build-wasm`