### PR TITLE
perf: optimize wasmer/cranelift in dev profile for faster tests

### DIFF
--- a/examples/guessing_game/template/Cargo.toml
+++ b/examples/guessing_game/template/Cargo.toml
@@ -19,3 +19,19 @@ lto = true          # Enable Link Time Optimization.
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic.
 strip = "debuginfo" # Strip debug info.
+
+# Wasmer and Cranelift are extremely slow when compiled in debug mode (~10x slower),
+# which makes template tests painfully slow. Optimize these specific crates even in
+# dev/test builds.
+[profile.dev.package.wasmer]
+opt-level = 2
+[profile.dev.package.wasmer-compiler]
+opt-level = 2
+[profile.dev.package.wasmer-compiler-cranelift]
+opt-level = 2
+[profile.dev.package.cranelift-codegen]
+opt-level = 2
+[profile.dev.package.cranelift-frontend]
+opt-level = 2
+[profile.dev.package.cranelift-entity]
+opt-level = 2

--- a/project_templates/nft_marketplace/templates/auction/Cargo.toml
+++ b/project_templates/nft_marketplace/templates/auction/Cargo.toml
@@ -17,6 +17,22 @@ lto = true          # Enable Link Time Optimization.
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic.
 strip = "debuginfo" # Strip debug info.
+
+# Wasmer and Cranelift are extremely slow when compiled in debug mode (~10x slower),
+# which makes template tests painfully slow. Optimize these specific crates even in
+# dev/test builds.
+[profile.dev.package.wasmer]
+opt-level = 2
+[profile.dev.package.wasmer-compiler]
+opt-level = 2
+[profile.dev.package.wasmer-compiler-cranelift]
+opt-level = 2
+[profile.dev.package.cranelift-codegen]
+opt-level = 2
+[profile.dev.package.cranelift-frontend]
+opt-level = 2
+[profile.dev.package.cranelift-entity]
+opt-level = 2
 {% endif %}
 
 [lib]

--- a/wasm_templates/airdrop/Cargo.toml
+++ b/wasm_templates/airdrop/Cargo.toml
@@ -17,6 +17,22 @@ lto = true          # Enable Link Time Optimization.
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic.
 strip = true
+
+# Wasmer and Cranelift are extremely slow when compiled in debug mode (~10x slower),
+# which makes template tests painfully slow. Optimize these specific crates even in
+# dev/test builds.
+[profile.dev.package.wasmer]
+opt-level = 2
+[profile.dev.package.wasmer-compiler]
+opt-level = 2
+[profile.dev.package.wasmer-compiler-cranelift]
+opt-level = 2
+[profile.dev.package.cranelift-codegen]
+opt-level = 2
+[profile.dev.package.cranelift-frontend]
+opt-level = 2
+[profile.dev.package.cranelift-entity]
+opt-level = 2
 {% endif %}
 
 [lib]

--- a/wasm_templates/counter/Cargo.toml
+++ b/wasm_templates/counter/Cargo.toml
@@ -18,6 +18,22 @@ lto = true          # Enable Link Time Optimization.
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic.
 strip = true
+
+# Wasmer and Cranelift are extremely slow when compiled in debug mode (~10x slower),
+# which makes template tests painfully slow. Optimize these specific crates even in
+# dev/test builds.
+[profile.dev.package.wasmer]
+opt-level = 2
+[profile.dev.package.wasmer-compiler]
+opt-level = 2
+[profile.dev.package.wasmer-compiler-cranelift]
+opt-level = 2
+[profile.dev.package.cranelift-codegen]
+opt-level = 2
+[profile.dev.package.cranelift-frontend]
+opt-level = 2
+[profile.dev.package.cranelift-entity]
+opt-level = 2
 {% endif %}
 
 [lib]

--- a/wasm_templates/empty/Cargo.toml
+++ b/wasm_templates/empty/Cargo.toml
@@ -19,6 +19,22 @@ lto = true          # Enable Link Time Optimization.
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic.
 strip = true
+
+# Wasmer and Cranelift are extremely slow when compiled in debug mode (~10x slower),
+# which makes template tests painfully slow. Optimize these specific crates even in
+# dev/test builds.
+[profile.dev.package.wasmer]
+opt-level = 2
+[profile.dev.package.wasmer-compiler]
+opt-level = 2
+[profile.dev.package.wasmer-compiler-cranelift]
+opt-level = 2
+[profile.dev.package.cranelift-codegen]
+opt-level = 2
+[profile.dev.package.cranelift-frontend]
+opt-level = 2
+[profile.dev.package.cranelift-entity]
+opt-level = 2
 {% endif %}
 
 [lib]

--- a/wasm_templates/fungible/Cargo.toml
+++ b/wasm_templates/fungible/Cargo.toml
@@ -18,6 +18,22 @@ lto = true          # Enable Link Time Optimization.
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic.
 strip = true
+
+# Wasmer and Cranelift are extremely slow when compiled in debug mode (~10x slower),
+# which makes template tests painfully slow. Optimize these specific crates even in
+# dev/test builds.
+[profile.dev.package.wasmer]
+opt-level = 2
+[profile.dev.package.wasmer-compiler]
+opt-level = 2
+[profile.dev.package.wasmer-compiler-cranelift]
+opt-level = 2
+[profile.dev.package.cranelift-codegen]
+opt-level = 2
+[profile.dev.package.cranelift-frontend]
+opt-level = 2
+[profile.dev.package.cranelift-entity]
+opt-level = 2
 {% endif %}
 
 [lib]

--- a/wasm_templates/ico/Cargo.toml
+++ b/wasm_templates/ico/Cargo.toml
@@ -17,6 +17,22 @@ lto = true          # Enable Link Time Optimization.
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic.
 strip = true
+
+# Wasmer and Cranelift are extremely slow when compiled in debug mode (~10x slower),
+# which makes template tests painfully slow. Optimize these specific crates even in
+# dev/test builds.
+[profile.dev.package.wasmer]
+opt-level = 2
+[profile.dev.package.wasmer-compiler]
+opt-level = 2
+[profile.dev.package.wasmer-compiler-cranelift]
+opt-level = 2
+[profile.dev.package.cranelift-codegen]
+opt-level = 2
+[profile.dev.package.cranelift-frontend]
+opt-level = 2
+[profile.dev.package.cranelift-entity]
+opt-level = 2
 {% endif %}
 
 [lib]

--- a/wasm_templates/meme_coin/Cargo.toml
+++ b/wasm_templates/meme_coin/Cargo.toml
@@ -17,6 +17,22 @@ lto = true          # Enable Link Time Optimization.
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic.
 strip = true
+
+# Wasmer and Cranelift are extremely slow when compiled in debug mode (~10x slower),
+# which makes template tests painfully slow. Optimize these specific crates even in
+# dev/test builds.
+[profile.dev.package.wasmer]
+opt-level = 2
+[profile.dev.package.wasmer-compiler]
+opt-level = 2
+[profile.dev.package.wasmer-compiler-cranelift]
+opt-level = 2
+[profile.dev.package.cranelift-codegen]
+opt-level = 2
+[profile.dev.package.cranelift-frontend]
+opt-level = 2
+[profile.dev.package.cranelift-entity]
+opt-level = 2
 {% endif %}
 
 [lib]

--- a/wasm_templates/nft/Cargo.toml
+++ b/wasm_templates/nft/Cargo.toml
@@ -20,6 +20,22 @@ lto = true          # Enable Link Time Optimization.
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic.
 strip = true
+
+# Wasmer and Cranelift are extremely slow when compiled in debug mode (~10x slower),
+# which makes template tests painfully slow. Optimize these specific crates even in
+# dev/test builds.
+[profile.dev.package.wasmer]
+opt-level = 2
+[profile.dev.package.wasmer-compiler]
+opt-level = 2
+[profile.dev.package.wasmer-compiler-cranelift]
+opt-level = 2
+[profile.dev.package.cranelift-codegen]
+opt-level = 2
+[profile.dev.package.cranelift-frontend]
+opt-level = 2
+[profile.dev.package.cranelift-entity]
+opt-level = 2
 {% endif %}
 
 [lib]

--- a/wasm_templates/no_std/Cargo.toml
+++ b/wasm_templates/no_std/Cargo.toml
@@ -21,6 +21,22 @@ lto = true          # Enable Link Time Optimization.
 codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic.
 strip = true
+
+# Wasmer and Cranelift are extremely slow when compiled in debug mode (~10x slower),
+# which makes template tests painfully slow. Optimize these specific crates even in
+# dev/test builds.
+[profile.dev.package.wasmer]
+opt-level = 2
+[profile.dev.package.wasmer-compiler]
+opt-level = 2
+[profile.dev.package.wasmer-compiler-cranelift]
+opt-level = 2
+[profile.dev.package.cranelift-codegen]
+opt-level = 2
+[profile.dev.package.cranelift-frontend]
+opt-level = 2
+[profile.dev.package.cranelift-entity]
+opt-level = 2
 {% endif %}
 
 [lib]

--- a/wasm_templates/stable_coin/Cargo.toml
+++ b/wasm_templates/stable_coin/Cargo.toml
@@ -19,5 +19,21 @@ codegen-units = 1   # Reduce number of codegen units to increase optimizations.
 panic = 'abort'     # Abort on panic.
 strip = true
 
+# Wasmer and Cranelift are extremely slow when compiled in debug mode (~10x slower),
+# which makes template tests painfully slow. Optimize these specific crates even in
+# dev/test builds.
+[profile.dev.package.wasmer]
+opt-level = 2
+[profile.dev.package.wasmer-compiler]
+opt-level = 2
+[profile.dev.package.wasmer-compiler-cranelift]
+opt-level = 2
+[profile.dev.package.cranelift-codegen]
+opt-level = 2
+[profile.dev.package.cranelift-frontend]
+opt-level = 2
+[profile.dev.package.cranelift-entity]
+opt-level = 2
+
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
## Summary
- Add `[profile.dev.package.*]` with `opt-level = 2` for wasmer and cranelift crates across all 11 template `Cargo.toml` files
- Wasmer and Cranelift are ~10x slower when compiled in debug mode, making template tests painfully slow
- Optimizes only the JIT-heavy crates (`wasmer`, `wasmer-compiler`, `wasmer-compiler-cranelift`, `cranelift-codegen`, `cranelift-frontend`, `cranelift-entity`) without affecting the rest of the project

## Test plan
- [ ] Run `cargo test` on individual templates to verify tests pass and are noticeably faster
- [ ] Verify templates render correctly with `in_cargo_workspace == "false"` (profile sections inside conditional blocks)
- [ ] Verify standalone templates (stable_coin, guessing_game) work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)