### PR TITLE
chore: prep templates for tari_template_lib 0.27

### DIFF
--- a/examples/guessing_game/cli/Cargo.lock
+++ b/examples/guessing_game/cli/Cargo.lock
@@ -160,9 +160,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -399,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -698,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -837,7 +837,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -1201,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1300,9 +1300,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -1513,7 +1513,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1624,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1871,9 +1871,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -3015,9 +3015,9 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "5.3.1-pre.1"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516e329ec417f8fb86da0d7cfc7c42c6c5d9c8f357a1b45d1fe0c7a6e6a8378a"
+checksum = "5fdd7804e44f51c2f8ae438ccc2805aeef0842ce8120f856f47f5b982e6652ca"
 dependencies = [
  "anyhow",
  "cargo_toml 0.20.5",
@@ -3039,9 +3039,9 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "5.3.1-pre.1"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15dd3d500d2e59e380d75d6cc1a44b40248597694f910764c4ba67ea78beb59a"
+checksum = "6a5ea88eaac18365959193142a7699b48ddb67cdcfc6e809fbc87fd2423f8a79"
 dependencies = [
  "argon2 0.6.0-rc.8",
  "base64 0.22.1",
@@ -3149,15 +3149,15 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "5.3.1-pre.1"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9321b2a14632fa572d10bd05bccaecc4ca996d95d47e896c12c72fd52e5a4f26"
+checksum = "8bb0c46e65c7731d8a8ddf07ca9f9b9f7833fac40bb16cff864ef7d06f2b9634"
 
 [[package]]
 name = "tari_hashing"
-version = "5.3.1-pre.1"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "690fda9301fdee1215debf6ff05b777fc5ff81b3d3d11478c6961126d2029240"
+checksum = "f3bb7a220ed807019f4455177dc7d523477c22b666ef2c7c63791305fadda728"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -3195,9 +3195,9 @@ dependencies = [
 
 [[package]]
 name = "tari_jellyfish"
-version = "5.3.1-pre.1"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8b7d57e7b14cb80cac39c9b66d90e7cc4b44b4f455da974c4fb834646548aa"
+checksum = "6f81a3e556437e19872b57eee30c740880b3621a4c957cc110a7f67aa73054b9"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -3210,9 +3210,9 @@ dependencies = [
 
 [[package]]
 name = "tari_max_size"
-version = "5.3.1-pre.1"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3e9925a69b4bd83001878decd10ace5b56367306d1eaaa4dbca45b6f58106"
+checksum = "289b2e2524a8e5f889d9a861a6df222c391921f2ba568101e87a80ec91fe8d97"
 dependencies = [
  "borsh",
  "serde",
@@ -3351,9 +3351,9 @@ dependencies = [
 
 [[package]]
 name = "tari_sidechain"
-version = "5.3.1-pre.1"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428f77d3384b10c7cb6587f5e096ae4b62f61995016e5964d47cf587383d14d5"
+checksum = "3c719acd1516056073124688c01370674ddb8d6275218bfbb944b0ee439b9cae"
 dependencies = [
  "borsh",
  "hex",
@@ -3589,9 +3589,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -3713,7 +3713,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -3722,7 +3722,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -3754,9 +3754,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
@@ -4012,9 +4012,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4025,9 +4025,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4035,9 +4035,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4045,9 +4045,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4058,9 +4058,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -4114,9 +4114,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4374,9 +4374,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -4541,9 +4541,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/examples/guessing_game/cli/Cargo.lock
+++ b/examples/guessing_game/cli/Cargo.lock
@@ -468,33 +468,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
-]
-
-[[package]]
 name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1218,17 +1191,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1809,6 +1771,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minicbor"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b7a5041e12946f8b7d3f5a9d96383a19d694b9335457c522be7815b9abafb02"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c9303a7d70578b101a21b3043ade4ab825c59063bbcd89af1066729399b79c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,19 +1911,20 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "ootle-network"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3932a49c75b4d7099988c5df7e51028a0d003f817cb557b00becb81039450bf"
+checksum = "bbaa04b000c9d51e701385c1369c53b1123a81eec862d8c595e6c44e0beb8015"
 dependencies = [
+ "minicbor",
  "serde",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "ootle-rs"
-version = "0.6.6"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c88fe8c072b045b626f99cf1d8441d559684b4e95cc5231499f407d0ada87efe"
+checksum = "e204e8dcf0cfba10453e50d57a5dc1d6b8ec5dafeaaf746098dc89a0a1e781b4"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1969,9 +1952,9 @@ dependencies = [
 
 [[package]]
 name = "ootle_byte_type"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50fcc9c7b06bd31ce2e6f7b3fae3095b35bc1caa1ed3a7393238b1b8f7bb3c67"
+checksum = "99ed5152cd8bb0d86a177840f52370be19f01dad9dc671bb584b7091f3aa0e2a"
 dependencies = [
  "tari_crypto",
  "tari_template_lib_types",
@@ -1979,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "ootle_serde"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ebf90e42bffb2436ce6732a023b0cd48de62c981fcbfdef88fa4b3b7f31d867"
+checksum = "e62bc4bf713545a4636ad89ff60fc474a519aab100745214835b53e197642a44"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -2998,13 +2981,13 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tari_bor"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a42eeda12c38655b5a348e0ab99370affc27477eadd6af0a6736374ecf0ef68"
+checksum = "6c8724c7349ef374526ae1e9cb3944a98a6af8c1c4b30f5d3581d777f8a96a7a"
 dependencies = [
  "borsh",
- "ciborium",
- "ciborium-io",
+ "indexmap",
+ "minicbor",
  "serde",
 ]
 
@@ -3094,13 +3077,15 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.30.4"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "303dbeb837e2a43afb26bb7587756e8e240293666e5bec5dd257e5984d27eddc"
+checksum = "7f5d466ed5f3de8d50d1f5b7dff5a8f86e18d3f3a7f6f4c47ae34265267fcd7f"
 dependencies = [
  "borsh",
+ "minicbor",
  "ootle_serde",
  "serde",
+ "tari_bor",
  "tari_common_types",
  "tari_crypto",
  "tari_engine_types",
@@ -3134,9 +3119,9 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.30.4"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4ec37a6078cd7f677500931c111f520e3ec342c29f053c30ee5151e5894c72"
+checksum = "3a697456c185551a0566e2323963b435ae820fd26dd0a97bf624ba4c910fd566"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -3146,6 +3131,7 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "log",
+ "minicbor",
  "newtype-ops",
  "ootle_byte_type",
  "ootle_serde",
@@ -3181,9 +3167,9 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.30.2"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba51e87c955179506a0adf11cf4a66932f0dd3e049105f7b4d97d89a28b9625"
+checksum = "a9b47d4f510c7944e9a5ddcfd23e597c0a4c46c4e5fa8e70a14e247d960896c3"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -3248,9 +3234,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_address"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5ec304d9a17858cc7c2c0773b3df3a1beb0d1887f898ae6f4388af28b58f91"
+checksum = "be93a3494f07bd590a818bb9e057520bb9ca095291098b7587cb01c1973365be"
 dependencies = [
  "bech32",
  "ootle-network",
@@ -3262,9 +3248,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.30.4"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6441df17b67d86407e4b7c75a2d8f9360651c7e27bfd6cd3a1438bdcfb94cd1d"
+checksum = "1d7a9aefd442cf4a73e3c130a30fa42c6f6aaa2261ac82c07eaa571de0c6c63e"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -3272,6 +3258,7 @@ dependencies = [
  "digest 0.10.7",
  "ethnum",
  "indexmap",
+ "minicbor",
  "newtype-ops",
  "ootle-network",
  "ootle_byte_type",
@@ -3291,14 +3278,15 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_metadata"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d50bf2db305d20c1b299080d94a5c5a9eb92eca9c248f74e96d527b806819f"
+checksum = "e2869db740d797c733974cf8a098decceae256efce0f37aee3343445d5092015"
 dependencies = [
  "borsh",
  "cargo_toml 0.22.3",
  "gix-hash",
  "hex",
+ "minicbor",
  "multihash",
  "serde",
  "sha2",
@@ -3310,14 +3298,15 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.30.4"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e953cabce9cfc8a137ccdbdd5cb583e05b2b63708ed683e8e2d316dcc3ee0c10"
+checksum = "3cfbd7b984f705c4afb3913ec9e54ceff9b76c7bfa543e84338da9bd9b9fca8e"
 dependencies = [
  "borsh",
  "hex",
  "indexmap",
  "log",
+ "minicbor",
  "ootle-network",
  "ootle_byte_type",
  "ootle_serde",
@@ -3335,9 +3324,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.30.4"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d719cd55939a1b60cb5059108ff0e529c43d49e90de7138e4609fc45ac1fea6e"
+checksum = "9a5c2d55ef893d852460570a51f79f36b8278a6a8e1a805292415a88f5448f0c"
 dependencies = [
  "argon2 0.5.3",
  "blake2 0.10.6",
@@ -3380,10 +3369,11 @@ dependencies = [
 
 [[package]]
 name = "tari_template_abi"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9c1bb8738495f2662fc406aa8d39f4b0835518d7f83ef71e155bc5e14d06854"
+checksum = "3f191f916d35dfcc08fda805c397291fafc14dbc032e2f2f5c20b0a76eda22c7"
 dependencies = [
+ "minicbor",
  "serde",
  "tari_bor",
  "xxhash-rust",
@@ -3391,9 +3381,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.30.4"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1b7c2ac9ce850efc7ac5a1828810838447f602dc51c11c276b376e851fe7ef"
+checksum = "c940bbf2d3729c9fed4a78ce7d1a9cd032591a4de6da2a6364cf44716b241727"
 dependencies = [
  "anyhow",
  "tari_template_lib_types",
@@ -3401,11 +3391,12 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.26.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "676f05986e7fb50c2fc5f257b87d5c2826ae801cb88c0ee4d3177339a0477087"
+checksum = "229d384ec06be2c3cb20b118b026dca89f9e145f4379c99081f8ecded34e6104"
 dependencies = [
  "borsh",
+ "minicbor",
  "serde",
  "tari_bor",
  "tari_template_abi",
@@ -3415,12 +3406,13 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib_types"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11b5b9907f6c68200b1b48c2622d9a7009a4f52ffba9364021c0a7fa34c981f"
+checksum = "6df30557bfd468625a266e5fb4c37a4114c94cdce35d127cd01279c82f6f6d5d"
 dependencies = [
  "bnum",
  "borsh",
+ "minicbor",
  "num-integer",
  "serde",
  "tari_bor",
@@ -3429,9 +3421,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_macros"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c0cd833e57f4a66846d11ec042c73eafa0da024ed77b401cc1a657f4aa578bc"
+checksum = "479aabf617eccc8388a8d3461b3b65dc8996d22ea27372fd1d5530a6b0fff2d1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/guessing_game/cli/Cargo.toml
+++ b/examples/guessing_game/cli/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 ootle-rs = "0.6"
 tari_ootle_transaction = "0.30"
 tari_ootle_common_types = "0.30"
-tari_template_lib_types = "0.26"
+tari_template_lib_types = "0.27"
 tari_crypto = "0.23"
 tari_utilities = "0.10"
 

--- a/examples/guessing_game/cli/Cargo.toml
+++ b/examples/guessing_game/cli/Cargo.toml
@@ -10,9 +10,9 @@ name = "guessing-game-cli"
 path = "src/main.rs"
 
 [dependencies]
-ootle-rs = "0.6"
-tari_ootle_transaction = "0.30"
-tari_ootle_common_types = "0.30"
+ootle-rs = "0.7"
+tari_ootle_transaction = "0.31"
+tari_ootle_common_types = "0.31"
 tari_template_lib_types = "0.27"
 tari_crypto = "0.23"
 tari_utilities = "0.10"

--- a/examples/guessing_game/template/Cargo.lock
+++ b/examples/guessing_game/template/Cargo.lock
@@ -350,33 +350,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
-]
-
-[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,12 +607,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1050,17 +1017,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1455,6 +1411,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicbor"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b7a5041e12946f8b7d3f5a9d96383a19d694b9335457c522be7815b9abafb02"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c9303a7d70578b101a21b3043ade4ab825c59063bbcd89af1066729399b79c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1574,19 +1550,20 @@ dependencies = [
 
 [[package]]
 name = "ootle-network"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3932a49c75b4d7099988c5df7e51028a0d003f817cb557b00becb81039450bf"
+checksum = "bbaa04b000c9d51e701385c1369c53b1123a81eec862d8c595e6c44e0beb8015"
 dependencies = [
+ "minicbor",
  "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "ootle_byte_type"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50fcc9c7b06bd31ce2e6f7b3fae3095b35bc1caa1ed3a7393238b1b8f7bb3c67"
+checksum = "99ed5152cd8bb0d86a177840f52370be19f01dad9dc671bb584b7091f3aa0e2a"
 dependencies = [
  "tari_crypto",
  "tari_template_lib_types",
@@ -1594,9 +1571,9 @@ dependencies = [
 
 [[package]]
 name = "ootle_serde"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ebf90e42bffb2436ce6732a023b0cd48de62c981fcbfdef88fa4b3b7f31d867"
+checksum = "e62bc4bf713545a4636ad89ff60fc474a519aab100745214835b53e197642a44"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -2312,13 +2289,13 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tari_bor"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a42eeda12c38655b5a348e0ab99370affc27477eadd6af0a6736374ecf0ef68"
+checksum = "6c8724c7349ef374526ae1e9cb3944a98a6af8c1c4b30f5d3581d777f8a96a7a"
 dependencies = [
  "borsh",
- "ciborium",
- "ciborium-io",
+ "indexmap",
+ "minicbor",
  "serde",
 ]
 
@@ -2368,9 +2345,9 @@ dependencies = [
 
 [[package]]
 name = "tari_engine"
-version = "0.30.4"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "471ab90f50c6131ddf14c6c4c7a66736ae47969ead3479a46c54a1d8e289fdc3"
+checksum = "4a3cd429e4777d5b567c6102bf059641e46eda1e7192533d167713eafadd2915"
 dependencies = [
  "blake2",
  "indexmap",
@@ -2395,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.30.4"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4ec37a6078cd7f677500931c111f520e3ec342c29f053c30ee5151e5894c72"
+checksum = "3a697456c185551a0566e2323963b435ae820fd26dd0a97bf624ba4c910fd566"
 dependencies = [
  "blake2",
  "borsh",
@@ -2407,6 +2384,7 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "log",
+ "minicbor",
  "newtype-ops",
  "ootle_byte_type",
  "ootle_serde",
@@ -2448,9 +2426,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.30.4"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6441df17b67d86407e4b7c75a2d8f9360651c7e27bfd6cd3a1438bdcfb94cd1d"
+checksum = "1d7a9aefd442cf4a73e3c130a30fa42c6f6aaa2261ac82c07eaa571de0c6c63e"
 dependencies = [
  "blake2",
  "borsh",
@@ -2458,6 +2436,7 @@ dependencies = [
  "digest 0.10.7",
  "ethnum",
  "indexmap",
+ "minicbor",
  "newtype-ops",
  "ootle-network",
  "ootle_byte_type",
@@ -2477,10 +2456,11 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_build"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e62d128026a88d907092a16c27b92bfd7d19b211f92364f71a32f10eb5fb517f"
+checksum = "0fddc8ab59594730a7026572c45991cd6edc0906c54caa063fe79733f84c8281"
 dependencies = [
+ "syn 2.0.117",
  "tari_ootle_template_metadata",
  "thiserror",
  "url",
@@ -2488,14 +2468,15 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_metadata"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d50bf2db305d20c1b299080d94a5c5a9eb92eca9c248f74e96d527b806819f"
+checksum = "e2869db740d797c733974cf8a098decceae256efce0f37aee3343445d5092015"
 dependencies = [
  "borsh",
  "cargo_toml",
  "gix-hash",
  "hex",
+ "minicbor",
  "multihash",
  "serde",
  "serde_json",
@@ -2508,14 +2489,15 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.30.4"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e953cabce9cfc8a137ccdbdd5cb583e05b2b63708ed683e8e2d316dcc3ee0c10"
+checksum = "3cfbd7b984f705c4afb3913ec9e54ceff9b76c7bfa543e84338da9bd9b9fca8e"
 dependencies = [
  "borsh",
  "hex",
  "indexmap",
  "log",
+ "minicbor",
  "ootle-network",
  "ootle_byte_type",
  "ootle_serde",
@@ -2533,9 +2515,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.30.4"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d719cd55939a1b60cb5059108ff0e529c43d49e90de7138e4609fc45ac1fea6e"
+checksum = "9a5c2d55ef893d852460570a51f79f36b8278a6a8e1a805292415a88f5448f0c"
 dependencies = [
  "argon2",
  "blake2",
@@ -2561,10 +2543,11 @@ dependencies = [
 
 [[package]]
 name = "tari_template_abi"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9c1bb8738495f2662fc406aa8d39f4b0835518d7f83ef71e155bc5e14d06854"
+checksum = "3f191f916d35dfcc08fda805c397291fafc14dbc032e2f2f5c20b0a76eda22c7"
 dependencies = [
+ "minicbor",
  "serde",
  "tari_bor",
  "xxhash-rust",
@@ -2572,21 +2555,23 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.30.4"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1b7c2ac9ce850efc7ac5a1828810838447f602dc51c11c276b376e851fe7ef"
+checksum = "c940bbf2d3729c9fed4a78ce7d1a9cd032591a4de6da2a6364cf44716b241727"
 dependencies = [
  "anyhow",
+ "minicbor",
  "tari_template_lib_types",
 ]
 
 [[package]]
 name = "tari_template_lib"
-version = "0.26.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "676f05986e7fb50c2fc5f257b87d5c2826ae801cb88c0ee4d3177339a0477087"
+checksum = "229d384ec06be2c3cb20b118b026dca89f9e145f4379c99081f8ecded34e6104"
 dependencies = [
  "borsh",
+ "minicbor",
  "serde",
  "tari_bor",
  "tari_template_abi",
@@ -2596,12 +2581,13 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib_types"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11b5b9907f6c68200b1b48c2622d9a7009a4f52ffba9364021c0a7fa34c981f"
+checksum = "6df30557bfd468625a266e5fb4c37a4114c94cdce35d127cd01279c82f6f6d5d"
 dependencies = [
  "bnum",
  "borsh",
+ "minicbor",
  "num-integer",
  "serde",
  "tari_bor",
@@ -2610,9 +2596,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_macros"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c0cd833e57f4a66846d11ec042c73eafa0da024ed77b401cc1a657f4aa578bc"
+checksum = "479aabf617eccc8388a8d3461b3b65dc8996d22ea27372fd1d5530a6b0fff2d1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2622,9 +2608,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_test_tooling"
-version = "0.30.4"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7dc652bd287d495744f4d2ef659dabfb07fd0f199969e1cf0a1d7ad89ab0f6"
+checksum = "c274eba444ba3c80b99531abb95180ecc8a7a6a6ff24e86d9a04f5cf8a204098"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -2646,9 +2632,9 @@ dependencies = [
 
 [[package]]
 name = "tari_transaction_manifest"
-version = "0.30.4"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "641d2307b19c797b95be7fd7f83f656389cd6ca65e49a944fab0e2923b2e014e"
+checksum = "383263cefefd85faf8b7d0ced75a24d5e055248b6df6ce5b795f5053ac9271b2"
 dependencies = [
  "proc-macro2",
  "serde_json",

--- a/examples/guessing_game/template/Cargo.lock
+++ b/examples/guessing_game/template/Cargo.lock
@@ -285,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -621,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -747,7 +747,7 @@ checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -795,18 +795,18 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b07a8dfbbbfc0064c0a6bdf9edcf966de6b1c33ce344bdeca3b41615452634"
+checksum = "839c4174b41e75c8f7306110b2c51996a293b8d1d850edd529011841d9fede7d"
 dependencies = [
  "enumset_derive",
 ]
 
 [[package]]
 name = "enumset_derive"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43e744e4ea338060faee68ed933e46e722fb7f3617e722a5772d7e856d8b3ce"
+checksum = "4bd536557b58c682b217b8fb199afdff47cd3eff260623f19e77074eb073d63a"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -859,13 +859,12 @@ checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1042,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1069,9 +1068,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -1198,7 +1197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1247,9 +1246,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1305,18 +1304,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "bitflags 2.11.1",
- "libc",
- "plain",
- "redox_syscall 0.7.5",
-]
 
 [[package]]
 name = "libunwind"
@@ -1605,7 +1592,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -1638,12 +1625,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "poly1305"
@@ -1878,15 +1859,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
 name = "regalloc2"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1958,7 +1930,7 @@ checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
 dependencies = [
  "bytecheck",
  "bytes",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "indexmap",
  "munge",
  "ptr_meta",
@@ -2043,9 +2015,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ruzstd"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
 dependencies = [
  "twox-hash",
 ]
@@ -2272,9 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -2402,9 +2374,9 @@ dependencies = [
 
 [[package]]
 name = "tari_hashing"
-version = "5.3.1-pre.1"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "690fda9301fdee1215debf6ff05b777fc5ff81b3d3d11478c6961126d2029240"
+checksum = "f3bb7a220ed807019f4455177dc7d523477c22b666ef2c7c63791305fadda728"
 dependencies = [
  "blake2",
  "borsh",
@@ -2596,9 +2568,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_macros"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479aabf617eccc8388a8d3461b3b65dc8996d22ea27372fd1d5530a6b0fff2d1"
+checksum = "32716528df28bcf1407c9cc40ada508cd34382dd5dee9d40ff7280aca8b05de9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2786,7 +2758,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -2795,7 +2767,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -2948,9 +2920,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2961,9 +2933,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2971,9 +2943,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2984,9 +2956,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -3003,12 +2975,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.248.0"
+version = "0.249.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
+checksum = "69830ccbbf41c55eb585991659fb70867ef628193af3a495f09a6956f7615e59"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.248.0",
+ "wasmparser 0.249.0",
 ]
 
 [[package]]
@@ -3212,9 +3184,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.248.0"
+version = "0.249.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
+checksum = "30538cae9a794215f490b532df01c557e2e2bfac92569482554acd0992a102ea"
 dependencies = [
  "bitflags 2.11.1",
  "indexmap",
@@ -3232,22 +3204,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "248.0.0"
+version = "249.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc54622ed5a5cddafcdf152043f9d4aed54d4a653d686b7dfe874809fca99d7"
+checksum = "2474a321bf9ae2808e9fa23ac4ec2b27300e70985e30bcb5a38d43b76bfc901a"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.248.0",
+ "wasm-encoder 0.249.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.248.0"
+version = "1.249.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75cd9e510603909748e6ebab89f27cd04472c1d9d85a3c88a7a6fc51a1a7934"
+checksum = "28af699d0a9c7e4e250b7b8e36167ae5215fbb4b7ae526bb4ce7b234ba0afc90"
 dependencies = [
  "wast",
 ]
@@ -3366,9 +3338,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -3534,9 +3506,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/examples/guessing_game/template/Cargo.toml
+++ b/examples/guessing_game/template/Cargo.toml
@@ -13,7 +13,7 @@ logo_url = "https://ootle.tari.com/favicon.png"
 homepage = "https://ootle.tari.com/"
 
 [dependencies]
-tari_template_lib = { version = "0.26" }
+tari_template_lib = { version = "0.27" }
 
 [dev-dependencies]
 tari_template_test_tooling = "0.30"

--- a/examples/guessing_game/template/Cargo.toml
+++ b/examples/guessing_game/template/Cargo.toml
@@ -16,7 +16,7 @@ homepage = "https://ootle.tari.com/"
 tari_template_lib = { version = "0.27" }
 
 [dev-dependencies]
-tari_template_test_tooling = "0.30"
+tari_template_test_tooling = "0.31"
 
 [lib]
 crate-type = ["cdylib"]
@@ -45,4 +45,4 @@ opt-level = 2
 opt-level = 2
 
 [build-dependencies]
-tari_ootle_template_build = "0.6"
+tari_ootle_template_build = "0.7"

--- a/examples/guessing_game/template/tari.config.toml
+++ b/examples/guessing_game/template/tari.config.toml
@@ -7,4 +7,4 @@ metadata-server-url = "http://localhost:3000/"
 [networks.esmeralda]
 wallet-daemon-url = "http://127.0.0.1:5100/json_rpc"
 metadata-server-url = "https://ootle-templates-esme.tari.com/"
-template-address = "template_6c3644b95c31650e0bdad163c24541fb8b29cec332be5c378babe5642764c9ef"
+template-address = "template_829f9900603293abf790036a98d5c273ee7fe908d623b07f026917dc72774482"

--- a/project_templates/nft_marketplace/templates/auction/Cargo.toml
+++ b/project_templates/nft_marketplace/templates/auction/Cargo.toml
@@ -8,7 +8,7 @@ tari_template_lib = "0.27"
 minicbor = { version = "2.2", default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]
-tari_template_test_tooling = "0.30"
+tari_template_test_tooling = "0.31"
 
 {% if in_cargo_workspace == "false" %}
 [profile.release]

--- a/project_templates/nft_marketplace/templates/auction/Cargo.toml
+++ b/project_templates/nft_marketplace/templates/auction/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-tari_template_lib = "0.26"
-serde = { version = "1.0", default-features = false, features = ["derive"] }
+tari_template_lib = "0.27"
+minicbor = { version = "2.2", default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]
 tari_template_test_tooling = "0.30"

--- a/project_templates/nft_marketplace/templates/auction/src/lib.rs
+++ b/project_templates/nft_marketplace/templates/auction/src/lib.rs
@@ -1,11 +1,13 @@
 use tari_template_lib::prelude::*;
 
 /// TODO: create constant in template_lib for account template address (and other builtin templates)
-pub const ACCOUNT_TEMPLATE_ADDRESS: Hash = Hash::from_array([0u8; 32]);
+pub const ACCOUNT_TEMPLATE_ADDRESS: TemplateAddress = TemplateAddress::from_array([0u8; 32]);
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
 pub struct Bid {
+    #[n(0)]
     bidder_account: ComponentAddress,
+    #[n(1)]
     vault: Vault,
 }
 
@@ -76,8 +78,10 @@ mod nft_marketplace {
             // create the bucket with the badge to allow the seller to cancel the auction at any time
             // we make sure that only the initial badge will be minted
             let seller_badge_bucket = ResourceBuilder::non_fungible()
-                .mintable(AccessRule::DenyAll)
-                .burnable(AccessRule::AllowAll)
+                // LOCKED makes each rule immutable after creation — fine for the
+                // single-mint badge lifecycle here.
+                .mintable(AccessRule::DenyAll, LOCKED)
+                .burnable(AccessRule::AllowAll, LOCKED)
                 .initial_supply_with_data(Some((NonFungibleId::random(), (&(), &()))));
             let seller_badge_resource = seller_badge_bucket.resource_address();
 
@@ -106,8 +110,8 @@ mod nft_marketplace {
 
             assert_eq!(
                 payment.resource_address(),
-                XTR,
-                "Invalid payment resource, the marketplace only accepts Tari (XTR) tokens"
+                TARI_TOKEN,
+                "Invalid payment resource, the marketplace only accepts Tari tokens"
             );
 
             // validate that the bidder account is really an account
@@ -130,7 +134,7 @@ mod nft_marketplace {
                 let previous_bidder_account = ComponentManager::get(highest_bid.bidder_account);
                 let refund_bucket = highest_bid.vault.withdraw_all();
                 // TODO: improve call method generics when there is no return value
-                previous_bidder_account.call::<_, ()>("deposit".to_string(), call_args![refund_bucket]);
+                previous_bidder_account.invoke("deposit", args![refund_bucket]);
 
                 // update the highest bidder in the auction
                 highest_bid.bidder_account = bidder_account_address;
@@ -187,7 +191,7 @@ mod nft_marketplace {
             if let Some(highest_bid) = &mut self.highest_bid {
                 let bidder_account = ComponentManager::get(highest_bid.bidder_account);
                 let refund_bucket = highest_bid.vault.withdraw_all();
-                bidder_account.call::<_, ()>("deposit".to_string(), call_args![refund_bucket]);
+                bidder_account.invoke("deposit", args![refund_bucket]);
                 // TODO: removing the bid ends up in a OrphanedSubstate error in the
                 //       but we need to mark that the auction is finished somehow to prevent new bids
                 // self.highest_bid = None;
@@ -199,7 +203,7 @@ mod nft_marketplace {
             // send the NFT back to the seller
             let seller_account = ComponentManager::get(self.seller_address);
             let nft_bucket = self.vault.withdraw_all();
-            seller_account.call::<_, ()>("deposit".to_string(), call_args![nft_bucket]);
+            seller_account.invoke("deposit", args![nft_bucket]);
         }
 
         fn assert_component_is_account(component_address: ComponentAddress) {
@@ -218,14 +222,14 @@ mod nft_marketplace {
             if let Some(highest_bid) = &mut self.highest_bid {
                 // deposit the nft to the bidder
                 let bidder_account = ComponentManager::get(highest_bid.bidder_account);
-                bidder_account.call::<_, ()>("deposit".to_string(), call_args![nft_bucket]);
+                bidder_account.invoke("deposit", args![nft_bucket]);
 
                 // deposit the funds to the seller
                 let payment = highest_bid.vault.withdraw_all();
-                seller_account.call::<_, ()>("deposit".to_string(), call_args![payment]);
+                seller_account.invoke("deposit", args![payment]);
             } else {
                 // no bidders in the auction, so just return the NFT to the seller
-                seller_account.call::<_, ()>("deposit".to_string(), call_args![nft_bucket]);
+                seller_account.invoke("deposit", args![nft_bucket]);
             }
 
             // TODO: burn the seller badge to avoid it being used again (should we recall it first?)

--- a/project_templates/nft_marketplace/templates/index/Cargo.toml
+++ b/project_templates/nft_marketplace/templates/index/Cargo.toml
@@ -4,9 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-#tari_template_lib = "*"
-tari_template_lib = {path = "../../../../dan/crates/template_lib"}
-serde = { version = "1.0", default-features = false, features = ["derive"] }
+tari_template_lib = "0.27"
 
 {% if in_cargo_workspace == "false" %}
 [profile.release]

--- a/project_templates/nft_marketplace/templates/index/src/lib.rs
+++ b/project_templates/nft_marketplace/templates/index/src/lib.rs
@@ -36,7 +36,7 @@ mod nft_marketplace_index {
         ) -> (ComponentAddress, Bucket) {
             // init the auction component
             let (auction_component, seller_badge): (ComponentAddress, Bucket) = TemplateManager::get(self.auction_template)
-                .call("new".to_string(), call_args![
+                .call("new", args![
                     nft_bucket,
                     seller_address,
                     min_price,

--- a/wasm_templates/airdrop/Cargo.toml
+++ b/wasm_templates/airdrop/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 tari_template_lib = { version = "0.27" }
 
 [dev-dependencies]
-tari_template_test_tooling = "0.30"
+tari_template_test_tooling = "0.31"
 
 {% if in_cargo_workspace == "false" %}
 [profile.release]

--- a/wasm_templates/airdrop/Cargo.toml
+++ b/wasm_templates/airdrop/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["{{authors}}"]
 edition = "2024"
 
 [dependencies]
-tari_template_lib = { version = "0.26" }
+tari_template_lib = { version = "0.27" }
 
 [dev-dependencies]
 tari_template_test_tooling = "0.30"

--- a/wasm_templates/airdrop/src/lib.rs
+++ b/wasm_templates/airdrop/src/lib.rs
@@ -8,7 +8,7 @@ pub mod {{ project-name | snake_case }} {
     pub struct {{ project-name | upper_camel_case }} {
         allow_list: BTreeSet<ComponentAddress>,
         is_airdrop_open: bool,
-        claimed_count: u128,
+        claimed_count: u64,
         vault: Vault,
     }
 
@@ -73,7 +73,7 @@ pub mod {{ project-name | snake_case }} {
             self.vault.get_resource_manager().total_supply()
         }
 
-        pub fn num_claimed(&self) -> u128 {
+        pub fn num_claimed(&self) -> u64 {
             self.claimed_count
         }
 
@@ -81,8 +81,10 @@ pub mod {{ project-name | snake_case }} {
             self.vault.balance()
         }
 
-        pub fn set_access_rules(&mut self, access_rules: ResourceAccessRules) {
-            self.vault.get_resource_manager().set_access_rules(access_rules)
+        pub fn update_access_rule(&mut self, action: ResourceAuthAction, new_rule: AccessRule) {
+            self.vault
+                .get_resource_manager()
+                .update_access_rule(action, new_rule)
         }
     }
 }

--- a/wasm_templates/counter/Cargo.toml
+++ b/wasm_templates/counter/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 tari_template_lib = "0.27"
 
 [dev-dependencies]
-tari_template_test_tooling = "0.30"
+tari_template_test_tooling = "0.31"
 
 
 {% if in_cargo_workspace == "false" %}

--- a/wasm_templates/counter/Cargo.toml
+++ b/wasm_templates/counter/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 
 
 [dependencies]
-tari_template_lib = "0.26"
+tari_template_lib = "0.27"
 
 [dev-dependencies]
 tari_template_test_tooling = "0.30"

--- a/wasm_templates/empty/Cargo.toml
+++ b/wasm_templates/empty/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 tari_template_lib = { version = "0.27" }
 
 [dev-dependencies]
-tari_template_test_tooling = "0.30"
+tari_template_test_tooling = "0.31"
 
 
 {% if in_cargo_workspace == "false" %}

--- a/wasm_templates/empty/Cargo.toml
+++ b/wasm_templates/empty/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 
 
 [dependencies]
-tari_template_lib = { version = "0.26" }
+tari_template_lib = { version = "0.27" }
 
 [dev-dependencies]
 tari_template_test_tooling = "0.30"

--- a/wasm_templates/fungible/Cargo.toml
+++ b/wasm_templates/fungible/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 tari_template_lib = { version = "0.27" }
 
 [dev-dependencies]
-tari_template_test_tooling = "0.30"
+tari_template_test_tooling = "0.31"
 
 {% if in_cargo_workspace == "false" %}
 [profile.release]

--- a/wasm_templates/fungible/Cargo.toml
+++ b/wasm_templates/fungible/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 
 
 [dependencies]
-tari_template_lib = { version = "0.26" }
+tari_template_lib = { version = "0.27" }
 
 [dev-dependencies]
 tari_template_test_tooling = "0.30"

--- a/wasm_templates/ico/Cargo.toml
+++ b/wasm_templates/ico/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 tari_template_lib = { version = "0.27" }
 
 [dev-dependencies]
-tari_template_test_tooling = "0.30"
+tari_template_test_tooling = "0.31"
 
 {% if in_cargo_workspace == "false" %}
 [profile.release]

--- a/wasm_templates/ico/Cargo.toml
+++ b/wasm_templates/ico/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["{{authors}}"]
 edition = "2024"
 
 [dependencies]
-tari_template_lib = { version = "0.26" }
+tari_template_lib = { version = "0.27" }
 
 [dev-dependencies]
 tari_template_test_tooling = "0.30"

--- a/wasm_templates/ico/src/lib.rs
+++ b/wasm_templates/ico/src/lib.rs
@@ -32,7 +32,7 @@ mod {{ project-name | snake_case }}_ico {
             (
                 Component::new(Self {
                     ico_tokens: Vault::from_bucket(coins),
-                    reward_coins: Vault::new_empty(XTR),
+                    reward_coins: Vault::new_empty(TARI_TOKEN),
                     token_price: price,
                 })
                     .with_owner_rule(OwnerRule::OwnedBySigner)
@@ -42,13 +42,13 @@ mod {{ project-name | snake_case }}_ico {
             )
         }
 
-        pub fn buy(&mut self, xtr_coins: Bucket) -> Bucket {
-            assert_eq!(xtr_coins.resource_address(), XTR, "You must pay with XTR!");
-            if xtr_coins.amount() < self.token_price {
-                panic!("Insufficient funds! You need more XTR to buy ICOs.");
+        pub fn buy(&mut self, payment: Bucket) -> Bucket {
+            assert_eq!(payment.resource_address(), TARI_TOKEN, "You must pay with Tari tokens!");
+            if payment.amount() < self.token_price {
+                panic!("Insufficient funds! You need more Tari to buy ICOs.");
             }
-            let ico_tokens_count = xtr_coins.amount() / self.token_price;
-            self.reward_coins.deposit(xtr_coins);
+            let ico_tokens_count = payment.amount() / self.token_price;
+            self.reward_coins.deposit(payment);
             self.ico_tokens.withdraw(ico_tokens_count)
         }
 

--- a/wasm_templates/meme_coin/Cargo.toml
+++ b/wasm_templates/meme_coin/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 tari_template_lib = { version = "0.27" }
 
 [dev-dependencies]
-tari_template_test_tooling = "0.30"
+tari_template_test_tooling = "0.31"
 
 {% if in_cargo_workspace == "false" %}
 [profile.release]

--- a/wasm_templates/meme_coin/Cargo.toml
+++ b/wasm_templates/meme_coin/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["{{authors}}"]
 edition = "2024"
 
 [dependencies]
-tari_template_lib = { version = "0.26" }
+tari_template_lib = { version = "0.27" }
 
 [dev-dependencies]
 tari_template_test_tooling = "0.30"

--- a/wasm_templates/meme_coin/src/lib.rs
+++ b/wasm_templates/meme_coin/src/lib.rs
@@ -33,8 +33,10 @@ pub mod {{ project-name | snake_case }} {
                 .create()
         }
 
-        pub fn set_access_rules(&mut self, access_rules: ResourceAccessRules) {
-            self.token_vault.get_resource_manager().set_access_rules(access_rules)
+        pub fn update_access_rule(&mut self, action: ResourceAuthAction, new_rule: AccessRule) {
+            self.token_vault
+                .get_resource_manager()
+                .update_access_rule(action, new_rule)
         }
 
         pub fn burn(&mut self, amount: Amount) {

--- a/wasm_templates/nft/Cargo.toml
+++ b/wasm_templates/nft/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_template_lib = { version = "0.26" }
-serde = { version = "1", features = ["derive"] }
+tari_template_lib = { version = "0.27" }
+minicbor = { version = "2.2", default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]
 tari_template_test_tooling = "0.30"

--- a/wasm_templates/nft/Cargo.toml
+++ b/wasm_templates/nft/Cargo.toml
@@ -11,7 +11,7 @@ tari_template_lib = { version = "0.27" }
 minicbor = { version = "2.2", default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]
-tari_template_test_tooling = "0.30"
+tari_template_test_tooling = "0.31"
 
 {% if in_cargo_workspace == "false" %}
 [profile.release]

--- a/wasm_templates/nft/src/lib.rs
+++ b/wasm_templates/nft/src/lib.rs
@@ -21,8 +21,9 @@
 //   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 use tari_template_lib::prelude::*;
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
 struct NftData {
+    #[n(0)]
     pub brightness: u32,
 }
 
@@ -41,7 +42,10 @@ mod {{ project-name | snake_case }} {
                 // TODO: specify stricter access rules as required
                 .with_access_rules(
                     ResourceAccessRules::new()
-                        .mintable(AccessRule::AllowAll)
+                        // LOCKED is a prelude constant — the configured mint rule cannot be
+                        // changed after creation. Swap to OWNER or a custom AccessRule if you
+                        // need to be able to update it later.
+                        .mintable(AccessRule::AllowAll, LOCKED)
                 )
                 .with_owner_rule(
                     OwnerRule::ByAccessRule(AccessRule::AllowAll)

--- a/wasm_templates/no_std/Cargo.toml
+++ b/wasm_templates/no_std/Cargo.toml
@@ -11,7 +11,7 @@ tari_template_lib = { version = "0.27", default-features = false, features = ["m
 talc = { version = "4.4.3", default-features = false, features = ["lock_api"] }
 
 [dev-dependencies]
-tari_template_test_tooling = "0.30"
+tari_template_test_tooling = "0.31"
 
 
 {% if in_cargo_workspace == "false" %}

--- a/wasm_templates/no_std/Cargo.toml
+++ b/wasm_templates/no_std/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 
 
 [dependencies]
-tari_template_lib = { version = "0.26", default-features = false, features = ["macro", "alloc"] }
+tari_template_lib = { version = "0.27", default-features = false, features = ["macro", "alloc"] }
 
 talc = { version = "4.4.3", default-features = false, features = ["lock_api"] }
 

--- a/wasm_templates/stable_coin/Cargo.toml
+++ b/wasm_templates/stable_coin/Cargo.toml
@@ -10,7 +10,7 @@ tari_template_lib = { version = "0.27" }
 minicbor = { version = "2.2", default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]
-tari_template_test_tooling = "0.30"
+tari_template_test_tooling = "0.31"
 
 [profile.release]
 opt-level = 's'     # Optimize for size.

--- a/wasm_templates/stable_coin/Cargo.toml
+++ b/wasm_templates/stable_coin/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2024"
 authors = ["{{authors}}"]
 
 [dependencies]
-tari_template_lib = { version = "0.26" }
-serde = { version = "1", default-features = false, features = ["derive"] }
+tari_template_lib = { version = "0.27" }
+minicbor = { version = "2.2", default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]
 tari_template_test_tooling = "0.30"

--- a/wasm_templates/stable_coin/src/lib.rs
+++ b/wasm_templates/stable_coin/src/lib.rs
@@ -45,12 +45,14 @@ mod template {
             let admin_resource = admin_badge.resource_address();
             let require_admin = rule!(resource(admin_resource));
 
-            // Create user badge resource
+            // Create user badge resource. OWNER lets the resource owner (this component,
+            // gated by the admin badge) update each rule later — swap to LOCKED if you want
+            // the rules to be permanently fixed at creation.
             let user_auth_resource = ResourceBuilder::non_fungible()
                 .add_metadata("provider_name", provider_name.trim())
-                .depositable(require_admin.clone())
-                .recallable(require_admin.clone())
-                .update_non_fungible_data(require_admin.clone())
+                .depositable(require_admin.clone(), OWNER)
+                .recallable(require_admin.clone(), OWNER)
+                .update_non_fungible_data(require_admin.clone(), OWNER)
                 .build();
 
             // Create user access rules
@@ -66,12 +68,13 @@ mod template {
             let initial_tokens = ResourceBuilder::confidential()
                 .with_metadata(token_metadata.clone())
                 .with_token_symbol(&token_symbol)
-                // Access rules
-                .mintable(require_admin.clone())
-                .burnable(require_admin.clone())
-                .depositable(require_user.clone())
-                .withdrawable(require_user.clone())
-                .recallable(require_admin.clone())
+                // Access rules. OWNER lets the resource owner (this component) update each
+                // rule later — swap to LOCKED to make any given rule permanent.
+                .mintable(require_admin.clone(), OWNER)
+                .burnable(require_admin.clone(), OWNER)
+                .depositable(require_user.clone(), OWNER)
+                .withdrawable(require_user.clone(), OWNER)
+                .recallable(require_admin.clone(), OWNER)
                 .with_authorization_hook(component_alloc.get_address(), "authorize_user_deposit")
                 .with_view_key(view_key)
                 .initial_supply(initial_supply_proof);
@@ -81,9 +84,9 @@ mod template {
                 let wrapped_resource = ResourceBuilder::public_fungible()
                     .with_metadata(token_metadata)
                     .with_token_symbol(format!("w{token_symbol}"))
-                    // Access rules
-                    .mintable(require_admin.clone())
-                    .burnable(require_admin.clone())
+                    // Access rules — see comment above on OWNER vs LOCKED.
+                    .mintable(require_admin.clone(), OWNER)
+                    .burnable(require_admin.clone(), OWNER)
                     .initial_supply(initial_token_supply);
 
                 Some(WrappedExchangeToken {

--- a/wasm_templates/stable_coin/src/user_data.rs
+++ b/wasm_templates/stable_coin/src/user_data.rs
@@ -5,9 +5,34 @@ use std::fmt::Display;
 use tari_template_lib::types::{ComponentAddress, NonFungibleId};
 use tari_template_lib::types::Amount;
 
-#[derive(Clone, Debug, Copy, serde::Serialize, serde::Deserialize)]
-#[serde(transparent)]
+#[derive(Clone, Debug, Copy)]
 pub struct UserId(u64);
+
+// UserId is a transparent newtype: on the wire it's just a CBOR u64, matching what manifests
+// emit for `123u64` literals. The derive macros would wrap the inner u64 in a single-element
+// array; we want bare u64 so the manifest path round-trips.
+impl<C> minicbor::Encode<C> for UserId {
+    fn encode<W: minicbor::encode::Write>(
+        &self,
+        e: &mut minicbor::Encoder<W>,
+        _ctx: &mut C,
+    ) -> Result<(), minicbor::encode::Error<W::Error>> {
+        e.u64(self.0)?;
+        Ok(())
+    }
+}
+
+impl<'b, C> minicbor::Decode<'b, C> for UserId {
+    fn decode(d: &mut minicbor::Decoder<'b>, _ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
+        Ok(UserId(d.u64()?))
+    }
+}
+
+impl<C> minicbor::CborLen<C> for UserId {
+    fn cbor_len(&self, ctx: &mut C) -> usize {
+        self.0.cbor_len(ctx)
+    }
+}
 
 impl From<UserId> for NonFungibleId {
     fn from(value: UserId) -> Self {
@@ -21,16 +46,21 @@ impl Display for UserId {
     }
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
 pub struct UserData {
+    #[n(0)]
     pub user_id: UserId,
+    #[n(1)]
     pub user_account: ComponentAddress,
+    #[n(2)]
     pub created_at: u64,
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
 pub struct UserMutableData {
+    #[n(0)]
     pub is_blacklisted: bool,
+    #[n(1)]
     pub wrapped_exchange_limit: Amount,
 }
 

--- a/wasm_templates/stable_coin/src/wrapped_exchange_token.rs
+++ b/wasm_templates/stable_coin/src/wrapped_exchange_token.rs
@@ -5,10 +5,12 @@ use tari_template_lib::models::Vault;
 use tari_template_lib::types::Amount;
 use tari_template_lib::resource::ResourceManager;
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
 pub enum ExchangeFee {
-    Fixed(Amount),
-    Percentage(u64),
+    #[n(0)]
+    Fixed(#[n(0)] Amount),
+    #[n(1)]
+    Percentage(#[n(0)] u64),
 }
 
 impl ExchangeFee {
@@ -23,9 +25,11 @@ impl ExchangeFee {
     }
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, minicbor::Encode, minicbor::Decode, minicbor::CborLen)]
 pub struct WrappedExchangeToken {
+    #[n(0)]
     pub vault: Vault,
+    #[n(1)]
     pub exchange_fee: ExchangeFee,
 }
 

--- a/wasm_templates/stable_coin/tests/test.rs
+++ b/wasm_templates/stable_coin/tests/test.rs
@@ -235,16 +235,18 @@ fn setup() -> TestSetup {
         .inspect_component(stable_coin_component)
         .unwrap();
 
+    // Component state is encoded with minicbor as a positional array, so look up fields by
+    // their #[n(N)] index rather than by name.
     let token_vault = indexed
-        .get_value("$.token_vault")
+        .get_value("$.0")
         .unwrap()
-        .expect("user_badge_resource not found");
+        .expect("token_vault not found");
     let user_badge_resource = indexed
-        .get_value("$.user_auth_resource")
+        .get_value("$.1")
         .unwrap()
         .expect("user_auth_resource not found");
     let admin_badge_resource = indexed
-        .get_value("$.admin_auth_resource")
+        .get_value("$.2")
         .unwrap()
         .expect("admin_auth_resource not found");
 

--- a/wasm_templates/swap/Cargo.toml
+++ b/wasm_templates/swap/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_template_lib = { version = "0.26" }
+tari_template_lib = { version = "0.27" }
 
 
 {% if in_cargo_workspace == "false" %}


### PR DESCRIPTION
## Summary


Prepares every template in the repo for `tari_template_lib` 0.27 (and `tari_template_lib_types` 0.27 for the CLI example). The version isn't published yet — when it is, the templates here will resolve without any further changes.

### What changed

- **Version bumps** (13 templates + 1 CLI): `0.26` → `0.27`. Test-tooling stays on `0.30`.
- **UpdateRule on resource access rules**: every `ResourceBuilder::*` access-rule call (`mintable`/`burnable`/`recallable`/`withdrawable`/`depositable`/`freezable`/`update_non_fungible_data`) now passes an `UpdateRule` updater alongside the `AccessRule`. Defaults — `LOCKED` for single-shot or starter templates (nft, auction badge), `OWNER` for stable_coin so the owner can still evolve rules later.
- **serde → minicbor migration** on the user types that flow through engine encode/decode paths: `NftData`, `Bid`, `UserData`, `UserMutableData`, `ExchangeFee`, `WrappedExchangeToken`. `UserId` keeps a hand-written impl so it stays a bare u64 on the wire — matches what manifests emit for `123u64` literals. Templates that didn't declare an explicit `serde` dep are left alone; the `#[template]` macro auto-derives minicbor for public types inside the template module.

### Drive-by fixes (pre-existing 0.26 → 0.27 API drift)

These were already broken against the local 0.27 tip; fixed so this branch verifies clean.

- `call_args!` macro is now `args!` (re-exported from prelude).
- `ComponentManager::call` now takes three generics — unit-returning sites switched to `.invoke("method", args![..])`.
- `Hash` type renamed to `Hash32`; account-template constant uses the `TemplateAddress` alias.
- `XTR` constant is deprecated — switched to `TARI_TOKEN`.
- `ResourceManager::set_access_rules` (bulk update) is gone — each template helper now wraps `update_access_rule(action, rule)`.
- airdrop's `claimed_count` switched from `u128` to `u64` (minicbor 2.2 has no native `Encode` for `u128`; the 100-cap airdrop never needed it).

### Verification

Each template was generated via `cargo generate` and `cargo check --target wasm32-unknown-unknown`'d against the local `tari-project/tari-ootle` repo via a `[patch.crates-io]` block:

| Template | Status |
| --- | --- |
| empty, counter, fungible, no_std, swap, ico, meme_coin, airdrop, nft, stable_coin | ✅ |
| nft_marketplace (auction + index workspace) | ✅ |
| guessing_game/template | ✅ |

## Test plan

- [ ] Wait for `tari_template_lib` 0.27 to publish to crates.io
- [ ] Drop this PR out of draft and run `scripts/test-templates.sh` against the published crates
- [ ] Confirm `cargo build --target wasm32-unknown-unknown` and the per-template tests all pass without `[patch.crates-io]`