### PR TITLE
chore: bump template deps to latest crates (0.28 / 0.35)

### DIFF
--- a/examples/guessing_game/cli/Cargo.lock
+++ b/examples/guessing_game/cli/Cargo.lock
@@ -64,15 +64,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -109,9 +109,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "async-stream"
@@ -132,7 +132,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -143,7 +143,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -197,6 +197,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base45"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240e56f4d3c453c36faacb695c535a4d5f8c7d23dac175014f32eb0a71012a03"
+
+[[package]]
 name = "base58-monero"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,12 +243,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -311,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
 dependencies = [
  "borsh-derive",
  "bytes",
@@ -323,15 +323,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -373,9 +373,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cargo_toml"
@@ -399,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -489,17 +489,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "bitflags 1.3.2",
- "textwrap",
- "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
@@ -529,7 +518,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -589,7 +578,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width 0.2.2",
+ "unicode-width",
  "windows-sys 0.61.2",
 ]
 
@@ -740,7 +729,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -766,7 +755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -796,7 +785,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -869,7 +858,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -973,12 +962,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,7 +1038,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1126,17 +1109,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
  "wasm-bindgen",
 ]
 
@@ -1156,7 +1137,7 @@ name = "guessing-game-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.6.1",
+ "clap",
  "dialoguer",
  "ootle-rs",
  "random-name",
@@ -1187,15 +1168,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
 ]
 
 [[package]]
@@ -1299,9 +1271,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -1450,12 +1422,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,7 +1468,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1512,7 +1478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown",
  "serde",
  "serde_core",
 ]
@@ -1589,7 +1555,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1608,7 +1574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1623,9 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1661,12 +1627,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1711,9 +1671,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 dependencies = [
  "serde_core",
 ]
@@ -1753,7 +1713,7 @@ checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1785,7 +1745,7 @@ checksum = "7c9303a7d70578b101a21b3043ade4ab825c59063bbcd89af1066729399b79c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1832,12 +1792,13 @@ dependencies = [
 
 [[package]]
 name = "multibase"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8694bb4835f452b0e3bb06dbebb1d6fc5385b6ca1caf2e55fd165c042390ec77"
+checksum = "7e0e4a371cbf1dfd666b658ba137763edb23c45beb43cfe369b5593cd6b437b6"
 dependencies = [
  "base-x",
  "base256emoji",
+ "base45",
  "data-encoding",
  "data-encoding-macro",
 ]
@@ -1920,9 +1881,9 @@ dependencies = [
 
 [[package]]
 name = "ootle-rs"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa6548aae014f7facb8bf66edffbc6cb5936b74e724e4a70c7bd91cdfb1215d"
+checksum = "8f6b93107bdfe02c46fbb22ac1238995704caac431ebe1e1779a78919fce8997"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1950,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "ootle_byte_type"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ed5152cd8bb0d86a177840f52370be19f01dad9dc671bb584b7091f3aa0e2a"
+checksum = "0548d6db83566dc083ce0227f5b2518f8e7a34b92bedbbc667ae0ac8f0f96e03"
 dependencies = [
  "tari_crypto",
  "tari_template_lib_types",
@@ -2016,7 +1977,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2036,7 +1997,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "phc",
 ]
 
@@ -2066,7 +2027,7 @@ checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
 dependencies = [
  "base64ct",
  "ctutils",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
 ]
 
 [[package]]
@@ -2117,16 +2078,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "primitive-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2145,30 +2096,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit 0.25.12+spec-1.1.0",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -2200,7 +2127,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2214,9 +2141,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2234,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -2270,9 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -2322,8 +2249,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20 0.10.0",
- "getrandom 0.4.2",
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -2506,7 +2433,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2515,9 +2442,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -2624,7 +2551,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2684,7 +2611,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2861,30 +2788,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "strum"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2921,9 +2824,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2947,7 +2850,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2956,7 +2859,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2979,9 +2882,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tari_bor"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90726af209c7ac949301c0e65f729f7e95183733a030a711d42d14ed9872d35a"
+checksum = "bdabc3ab961b415b5bc600b644b8b4c05d8934a52c0b4fe51cb9202844e7b7a7"
 dependencies = [
  "borsh",
  "indexmap",
@@ -2991,15 +2894,15 @@ dependencies = [
 
 [[package]]
 name = "tari_bulletproofs_plus"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2e5d22fc3d312561a24247689ac3ae180fb041e6ac11baf1317df3b1473ff8"
+checksum = "ed4257cfd0352ab95e186798feaa22f37a7de403e67ff32004c650e19f6bc1d6"
 dependencies = [
  "blake2 0.10.6",
  "byteorder",
  "curve25519-dalek",
  "digest 0.10.7",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "itertools 0.12.1",
  "once_cell",
  "rand_core 0.10.1",
@@ -3013,9 +2916,9 @@ dependencies = [
 
 [[package]]
 name = "tari_common"
-version = "5.4.0-pre.5"
+version = "5.4.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e750a0c3e0a90b887c58ca0089838b56ae31bc831861c709b9be1e3d866114f"
+checksum = "03dceaafea43bf5f39d0771337a485d2db33f99ede865b98278c0426d919db74"
 dependencies = [
  "anyhow",
  "cargo_toml 0.20.5",
@@ -3029,7 +2932,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
- "structopt",
  "tari_features",
  "tempfile",
  "thiserror 2.0.18",
@@ -3037,13 +2939,13 @@ dependencies = [
 
 [[package]]
 name = "tari_common_types"
-version = "5.4.0-pre.5"
+version = "5.4.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe80cb70db417f9ead06dffdbf9648224d8199aa6685b88e212ff90773671145"
+checksum = "55476767f8f53cc3bca684b22e2184962bab59923df66ba8d15d28dc6223ea79"
 dependencies = [
  "argon2 0.6.0-rc.8",
  "base64 0.22.1",
- "bitflags 2.13.0",
+ "bitflags",
  "blake2 0.10.6",
  "borsh",
  "bs58",
@@ -3052,7 +2954,7 @@ dependencies = [
  "crc32fast",
  "digest 0.10.7",
  "getrandom 0.2.17",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "newtype-ops",
  "once_cell",
@@ -3075,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "tari_consensus_types"
-version = "0.34.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5190e7cc5b207b39bfe6d983c03021c572ff9c98e28418b6d3881804d7ba83"
+checksum = "5d061aeefebfd14575601e4d94de3103398d0f6f1c49675eb7e65dab3b264cd6"
 dependencies = [
  "borsh",
  "minicbor",
@@ -3095,9 +2997,9 @@ dependencies = [
 
 [[package]]
 name = "tari_crypto"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330e2160d7d72970e8fc5f7074cdad1b041e32e996bbb6799215c9ccd03d5310"
+checksum = "5f139af279824e2e0925b169319397646c5e6c1e622b62548588e609eeef9c45"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -3117,9 +3019,9 @@ dependencies = [
 
 [[package]]
 name = "tari_engine_types"
-version = "0.34.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73d7565df19a5741fa26a01015afd407c83dca57535cbc01e00a149693641f4b"
+checksum = "01a65452fce0cb1d73bf1ec2e290b9a0c8b659e9181f46c056c145498b166f90"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -3136,6 +3038,7 @@ dependencies = [
  "rand 0.10.1",
  "serde",
  "serde_json",
+ "sha2",
  "tari_bor",
  "tari_crypto",
  "tari_hashing",
@@ -3147,15 +3050,15 @@ dependencies = [
 
 [[package]]
 name = "tari_features"
-version = "5.4.0-pre.5"
+version = "5.4.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e71b38ff2d5de33a30b350d031ffee5a12906f4a14f88b482994eb4a9a58be2e"
+checksum = "1e50c4283a96798248b98875baf71c530b1d802644cb4ec7a4b933b99ffed69e"
 
 [[package]]
 name = "tari_hashing"
-version = "5.4.0-pre.5"
+version = "5.4.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69ff43b336ff0cddc93cc2ca2f6f3717dc304e0dbba8b8e9b4b62c20f6233bc"
+checksum = "5cab6b508c741d26d1dc904cd8e01430dc705fe349e07184a552d3ffa4a020e2"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -3165,9 +3068,9 @@ dependencies = [
 
 [[package]]
 name = "tari_indexer_client"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11e14fa999bed4719a82fd5209b2b5ecfc7d97fbb53b36c9d2de73a92eca0449"
+checksum = "cc4fdc0f3b9d5f20b4b83ce955e105414a7416a684c84316b6a5398457209457"
 dependencies = [
  "anyhow",
  "bounded-vec",
@@ -3193,9 +3096,9 @@ dependencies = [
 
 [[package]]
 name = "tari_jellyfish"
-version = "5.4.0-pre.5"
+version = "5.4.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a24f96cc518f3480d9f841643b6b65ac8da5a9ac49854f6c6ea3bc4642818a"
+checksum = "ba442a0cca29e6bf7becc95f63d1ae7cd846ac2f7649fa65fefb86e4c58f6b72"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -3208,9 +3111,9 @@ dependencies = [
 
 [[package]]
 name = "tari_max_size"
-version = "5.4.0-pre.5"
+version = "5.4.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4364efa18264a97df678f97f540e7d05165f0d8cc54c2f2ff167cb10a425bf2f"
+checksum = "05ca6cccb9b80dbf75b86e131e75949404854a0f53f9f3936760b71ab7f1a7b3"
 dependencies = [
  "borsh",
  "serde",
@@ -3232,9 +3135,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_address"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be93a3494f07bd590a818bb9e057520bb9ca095291098b7587cb01c1973365be"
+checksum = "d4f97fb39c2e35a4f85e5ea0ade75c70ab9a1d1d1c8a2e37c45f7f20946839e4"
 dependencies = [
  "bech32",
  "ootle-network",
@@ -3246,9 +3149,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_common_types"
-version = "0.34.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d5f5bacd4d1c274597c3cf219cd8a0e38f57ef74bcb3aab892a45d0a7ab0396"
+checksum = "7e930e18f5b19a4b3876cb310313306ebfb94d14ea546074802dcec76294987c"
 dependencies = [
  "blake2 0.10.6",
  "borsh",
@@ -3276,9 +3179,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_template_metadata"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2869db740d797c733974cf8a098decceae256efce0f37aee3343445d5092015"
+checksum = "096675171d462ef7feee491540ac347af87b8ce3c54fe7d9be30116075b792ea"
 dependencies = [
  "borsh",
  "cargo_toml 0.22.3",
@@ -3296,9 +3199,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_transaction"
-version = "0.34.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9e47481239ad010c9bd7774c6d0342da13bf869d7df7d1d1121094bb8752ec"
+checksum = "a1d243eec3bd6fe844200798e9ffff7e7654111ae1892a0a4d699e85948de601"
 dependencies = [
  "borsh",
  "hex",
@@ -3322,9 +3225,9 @@ dependencies = [
 
 [[package]]
 name = "tari_ootle_wallet_crypto"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10cf2ccc4234e5bdcff93aab1e56c80c88a6725870017afd9e61ac84504908"
+checksum = "709add29f6bb1dc78b3250bf72216e61f7ee05ea11cb383b228e4a95c3bc1af5"
 dependencies = [
  "argon2 0.5.3",
  "blake2 0.10.6",
@@ -3349,9 +3252,9 @@ dependencies = [
 
 [[package]]
 name = "tari_sidechain"
-version = "5.4.0-pre.5"
+version = "5.4.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b3880396720f77ef8a533514ec4e9f52dea8a7cb993e8eb9ebca70e7c53c20"
+checksum = "801b65b9d7f71c039e89fe53df6a8ca4c2bbd041ab2cc6d65b69012c5e95b640"
 dependencies = [
  "borsh",
  "hex",
@@ -3367,9 +3270,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_abi"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d02e8f3235e2c0421da21248efb2370631174081ddf2e0d8fc030df184fad95b"
+checksum = "2c49d04c42c5dc5c297573953f2767a0e12a41893ab78ea1a1fb30329629dc11"
 dependencies = [
  "minicbor",
  "serde",
@@ -3379,9 +3282,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_builtin"
-version = "0.32.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3ea94593eb371bed225c4ea1a0f406307bb09496f34dcb2bfa5a4aa0d42943c"
+checksum = "e7c5f56e8bde8a20f098614a8f2d7c60b7bfb0fe30034b4c141a56a810128121"
 dependencies = [
  "anyhow",
  "tari_template_lib_types",
@@ -3389,9 +3292,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec68fc08a9cde8e709c6f8cb1bc078fcd1db6c794d0d95b595dcc2e8dc666b52"
+checksum = "a1e64b7c2d3cfdae2e1eb49525e77ebdd957f6cbfc9a27ac29f50c439c6f23a8"
 dependencies = [
  "borsh",
  "minicbor",
@@ -3404,9 +3307,9 @@ dependencies = [
 
 [[package]]
 name = "tari_template_lib_types"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "351ed3d15215e9878a0113746b6e391a41ab35976764f9a104aa25364b56115c"
+checksum = "1b2b8da56d82f520e139ba7f0f640657f5ddfa1e2aa852dd8d34c9a62b7f9d5c"
 dependencies = [
  "bnum",
  "borsh",
@@ -3419,13 +3322,13 @@ dependencies = [
 
 [[package]]
 name = "tari_template_macros"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32716528df28bcf1407c9cc40ada508cd34382dd5dee9d40ff7280aca8b05de9"
+checksum = "e7f2f8515b23f59706f636186d67c89e1efe678eea4921300a9eaf884e96e258"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tari_template_abi",
 ]
 
@@ -3454,19 +3357,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -3495,7 +3389,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3506,7 +3400,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3531,9 +3425,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "0e48db7b415311b615f910b3dcaa4557bcd4bf1982379c95c223fd8c2a20e210"
 dependencies = [
  "deranged",
  "num-conv",
@@ -3551,9 +3445,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3607,7 +3501,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3755,7 +3649,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -3798,7 +3692,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3854,12 +3748,6 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -3955,7 +3843,7 @@ checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3995,23 +3883,14 @@ version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4022,9 +3901,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4032,9 +3911,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4042,46 +3921,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -4098,22 +3955,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.13.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4131,9 +3976,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4380,97 +4225,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.13.0",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -4512,7 +4269,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -4533,7 +4290,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4553,7 +4310,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -4574,7 +4331,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4607,7 +4364,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/examples/guessing_game/cli/Cargo.toml
+++ b/examples/guessing_game/cli/Cargo.toml
@@ -10,10 +10,10 @@ name = "guessing-game-cli"
 path = "src/main.rs"
 
 [dependencies]
-ootle-rs = "0.12"
-tari_ootle_transaction = { version = "0.34", features = ["serde"] }
-tari_ootle_common_types = "0.34"
-tari_template_lib_types = "0.27"
+ootle-rs = "0.13"
+tari_ootle_transaction = { version = "0.35", features = ["serde"] }
+tari_ootle_common_types = "0.35"
+tari_template_lib_types = "0.28"
 tari_crypto = "0.23"
 tari_utilities = "0.10"
 

--- a/examples/guessing_game/template/Cargo.toml
+++ b/examples/guessing_game/template/Cargo.toml
@@ -13,10 +13,10 @@ logo_url = "https://ootle.tari.com/favicon.png"
 homepage = "https://ootle.tari.com/"
 
 [dependencies]
-tari_template_lib = { version = "0.27" }
+tari_template_lib = { version = "0.28" }
 
 [dev-dependencies]
-tari_template_test_tooling = "0.34"
+tari_template_test_tooling = "0.35"
 
 [lib]
 crate-type = ["cdylib"]
@@ -45,4 +45,4 @@ opt-level = 2
 opt-level = 2
 
 [build-dependencies]
-tari_ootle_template_build = "0.7"
+tari_ootle_template_build = "0.8"

--- a/project_templates/nft_marketplace/templates/auction/Cargo.toml
+++ b/project_templates/nft_marketplace/templates/auction/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-tari_template_lib = "0.27"
+tari_template_lib = "0.28"
 minicbor = { version = "2.2", default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]
-tari_template_test_tooling = "0.34"
+tari_template_test_tooling = "0.35"
 
 {% if in_cargo_workspace == "false" %}
 [profile.release]

--- a/project_templates/nft_marketplace/templates/index/Cargo.toml
+++ b/project_templates/nft_marketplace/templates/index/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-tari_template_lib = "0.27"
+tari_template_lib = "0.28"
 
 {% if in_cargo_workspace == "false" %}
 [profile.release]

--- a/wasm_templates/airdrop/Cargo.toml
+++ b/wasm_templates/airdrop/Cargo.toml
@@ -5,10 +5,10 @@ authors = ["{{authors}}"]
 edition = "2024"
 
 [dependencies]
-tari_template_lib = { version = "0.27" }
+tari_template_lib = { version = "0.28" }
 
 [dev-dependencies]
-tari_template_test_tooling = "0.34"
+tari_template_test_tooling = "0.35"
 
 {% if in_cargo_workspace == "false" %}
 [profile.release]

--- a/wasm_templates/counter/Cargo.toml
+++ b/wasm_templates/counter/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2024"
 
 
 [dependencies]
-tari_template_lib = "0.27"
+tari_template_lib = "0.28"
 
 [dev-dependencies]
-tari_template_test_tooling = "0.34"
+tari_template_test_tooling = "0.35"
 
 
 {% if in_cargo_workspace == "false" %}

--- a/wasm_templates/empty/Cargo.toml
+++ b/wasm_templates/empty/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2024"
 
 
 [dependencies]
-tari_template_lib = { version = "0.27" }
+tari_template_lib = { version = "0.28" }
 
 [dev-dependencies]
-tari_template_test_tooling = "0.34"
+tari_template_test_tooling = "0.35"
 
 
 {% if in_cargo_workspace == "false" %}

--- a/wasm_templates/fungible/Cargo.toml
+++ b/wasm_templates/fungible/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2024"
 
 
 [dependencies]
-tari_template_lib = { version = "0.27" }
+tari_template_lib = { version = "0.28" }
 
 [dev-dependencies]
-tari_template_test_tooling = "0.34"
+tari_template_test_tooling = "0.35"
 
 {% if in_cargo_workspace == "false" %}
 [profile.release]

--- a/wasm_templates/ico/Cargo.toml
+++ b/wasm_templates/ico/Cargo.toml
@@ -5,10 +5,10 @@ authors = ["{{authors}}"]
 edition = "2024"
 
 [dependencies]
-tari_template_lib = { version = "0.27" }
+tari_template_lib = { version = "0.28" }
 
 [dev-dependencies]
-tari_template_test_tooling = "0.34"
+tari_template_test_tooling = "0.35"
 
 {% if in_cargo_workspace == "false" %}
 [profile.release]

--- a/wasm_templates/meme_coin/Cargo.toml
+++ b/wasm_templates/meme_coin/Cargo.toml
@@ -5,10 +5,10 @@ authors = ["{{authors}}"]
 edition = "2024"
 
 [dependencies]
-tari_template_lib = { version = "0.27" }
+tari_template_lib = { version = "0.28" }
 
 [dev-dependencies]
-tari_template_test_tooling = "0.34"
+tari_template_test_tooling = "0.35"
 
 {% if in_cargo_workspace == "false" %}
 [profile.release]

--- a/wasm_templates/nft/Cargo.toml
+++ b/wasm_templates/nft/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_template_lib = { version = "0.27" }
+tari_template_lib = { version = "0.28" }
 minicbor = { version = "2.2", default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]
-tari_template_test_tooling = "0.34"
+tari_template_test_tooling = "0.35"
 
 {% if in_cargo_workspace == "false" %}
 [profile.release]

--- a/wasm_templates/no_std/Cargo.toml
+++ b/wasm_templates/no_std/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2024"
 
 
 [dependencies]
-tari_template_lib = { version = "0.27", default-features = false, features = ["macro", "alloc"] }
+tari_template_lib = { version = "0.28", default-features = false, features = ["macro", "alloc"] }
 
 talc = { version = "4.4.3", default-features = false, features = ["lock_api"] }
 
 [dev-dependencies]
-tari_template_test_tooling = "0.34"
+tari_template_test_tooling = "0.35"
 
 
 {% if in_cargo_workspace == "false" %}

--- a/wasm_templates/stable_coin/Cargo.toml
+++ b/wasm_templates/stable_coin/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2024"
 authors = ["{{authors}}"]
 
 [dependencies]
-tari_template_lib = { version = "0.27" }
+tari_template_lib = { version = "0.28" }
 minicbor = { version = "2.2", default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]
-tari_template_test_tooling = "0.34"
+tari_template_test_tooling = "0.35"
 
 [profile.release]
 opt-level = 's'     # Optimize for size.

--- a/wasm_templates/swap/Cargo.toml
+++ b/wasm_templates/swap/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tari_template_lib = { version = "0.27" }
+tari_template_lib = { version = "0.28" }
 
 
 {% if in_cargo_workspace == "false" %}


### PR DESCRIPTION
Bump `tari_template_lib` consumers to the latest crates.io releases across the wasm templates, project templates and guessing_game example.

## Version bumps
| Crate | Old | New |
|-------|-----|-----|
| `tari_template_lib` / `tari_template_lib_types` | 0.27 | **0.28** |
| `tari_template_test_tooling` | 0.34 | **0.35** |
| `tari_ootle_transaction` / `tari_ootle_common_types` | 0.34 | **0.35** |
| `tari_ootle_template_build` | 0.7 | **0.8** |
| `ootle-rs` (guessing_game cli) | 0.12 | **0.13** |

## Refreshed transitive deps (guessing_game cli `Cargo.lock`)
The cli lock is refreshed to the latest compatible transitive crates:
- **`tari_bor` 0.14.1 → 0.14.2** — `tari_template_lib_types 0.28.0` calls `tari_bor::adapters::boxed_slice::decode_with_fn`, which only exists from 0.14.2. The stale 0.14.1 lock caused `error[E0425]: cannot find function decode_with_fn in module boxed_slice`.
- **`tari_bulletproofs_plus` 0.5.0 → 0.5.1** — 0.5.1 constrains `curve25519-dalek` back to `5.0.0-pre.6`, avoiding the `5.0.0-rc.1` `ff`-backend break (`no method named pow_vartime`) — see tari-project/bulletproofs-plus#148. No manual `curve25519-dalek` pin is needed.
- **`tari_crypto` 0.23.0 → 0.23.1**

The lock-less library templates fresh-resolve to these same versions automatically.

## Verification
- `cargo build` on the guessing_game cli compiles cleanly (`decode_with_fn` resolved via `tari_bor 0.14.2`).
- `cargo test` on a generated `empty` template compiles the full host-side crypto stack and passes (`it_works ... ok`); fresh resolve picks `tari_bulletproofs_plus 0.5.1` + `curve25519-dalek 5.0.0-pre.6`.
- `cargo build --target wasm32-unknown-unknown --release` on a generated template compiles `tari_template_lib_types 0.28.0` against `tari_bor 0.14.2` cleanly.
- Full `scripts/test-templates.sh` suite left to CI.

## Note
`examples/guessing_game/template/tari.config.toml` still references the previously deployed `template-address`. That is a deployment artifact (requires a wallet daemon + network redeploy) and is intentionally left unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)